### PR TITLE
[do not merge] disable [tool.pixi-diff-to-markdown] reading from pixi.toml

### DIFF
--- a/pixi_diff_to_markdown/settings.py
+++ b/pixi_diff_to_markdown/settings.py
@@ -26,7 +26,7 @@ class HideTables(StrEnum):
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         # pixi.toml has higher priority if it exists
-        toml_file=["pyproject.toml", "pixi.toml"],
+        # toml_file=["pyproject.toml", "pixi.toml"],
         env_prefix="PIXI_DIFF_TO_MARKDOWN_",
         alias_generator=lambda x: x.replace("_", "-"),
     )


### PR DESCRIPTION
temporary fix to get https://github.com/pavelzw/pixi-diff-to-markdown/issues/104 to not complain anymore...

one can install this branch as a source dependency...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated configuration loading to use the default TOML file discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->