### PR TITLE
fix: support conda_source package records

### DIFF
--- a/pixi_diff_to_markdown/models.py
+++ b/pixi_diff_to_markdown/models.py
@@ -59,6 +59,8 @@ class PackageInformation(pydantic.BaseModel):
         # before v6, the build and version were stored explicitly in the lockfile
         # after v6, the build and version are stored implicitly in the conda url
         assert isinstance(data, dict)
+        if data.get("conda") is None and data.get("conda_source") is not None:
+            data["conda"] = data["conda_source"]
         if "conda" not in data and "pypi" not in data:
             # this maps all old lockfiles to conda packages, not pretty but should be fine
             build = data.get("build", "placeholder_0")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -76,6 +76,24 @@ def test_pypi_package_information_accepts_missing_version():
     assert package.version == "unknown"
 
 
+def test_conda_source_package_information():
+    source = (
+        "pixi-diff-to-markdown @ git+https://github.com/pavelzw/pixi-diff-to-markdown"
+    )
+    package = PackageInformation.model_validate(
+        {
+            "conda_source": source,
+            "conda": None,
+            "version": "0.3.9",
+            "build": "pyh4616a5c_0",
+        }
+    )
+
+    assert package.conda == source
+    assert package.version == "0.3.9"
+    assert package.build == "pyh4616a5c_0"
+
+
 @pytest.mark.parametrize("change_type_column", [False])
 @pytest.mark.parametrize("package_type_column", [False])
 @pytest.mark.parametrize("explicit_column", [True])


### PR DESCRIPTION
Pixi source records include `conda_source` alongside a null `conda`, so package validation rejected conda-to-source diffs. Normalize the source record to the existing conda representation while preserving its version and build metadata.

The regression test fails on the original code; all 211 tests, Ruff, and ty pass with the fix.

Fixes #110


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when reading package lockfile entries that specify a Conda source.
  * Preserves package version and build details during conversion.

* **Tests**
  * Added coverage to verify Conda source information is mapped correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->